### PR TITLE
Allow execution perms on the binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ COPY --chown=node:node --from=builder /app/bin ./bin
 COPY --chown=node:node --from=builder /app/lib ./lib
 COPY --chown=node:node --from=builder /app/node_modules ./node_modules
 
+# Allow executing the binary
+RUN chmod +x ./bin/faros-scan-result-reporter
+
 # We use tini so that node process does not run as PID 1
 # as doing so causes it to ignore certains signals like SIGINT.
 


### PR DESCRIPTION
The issue
```
Status: Downloaded newer image for farosai/faros-scan-results-reporter:latest
2024-05-07 16:32:14 PDT	[WARN  tini (7)] Tini is not running as PID 1 and isn't registered as a child subreaper.
2024-05-07 16:32:14 PDT	Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
2024-05-07 16:32:14 PDT	To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1.
2024-05-07 16:32:14 PDT	[FATAL tini (8)] exec ./bin/faros-scan-result-reporter failed: Permission denied
```