### PR TITLE
FAI-19161 Add Cobertura XML coverage format support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "p-limit": "^3.1.0",
         "pino": "^10.1.0",
         "pino-pretty": "^10.0.0",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "xml2js": "^0.6.2"
       },
       "bin": {
         "faros-scan-results-reporter": "faros-scan-results-reporter"
@@ -26,6 +27,7 @@
         "@types/luxon": "^3.3.6",
         "@types/node": "^20.10.0",
         "@types/uuid": "^9.0.7",
+        "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "eslint-plugin-simple-import-sort": "^12.0.0",
         "jest": "^29.7.0",
@@ -1397,6 +1399,16 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
       "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
       "dev": true
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -6187,6 +6199,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -7175,6 +7196,28 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {
@@ -8314,6 +8357,15 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
       "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
       "dev": true
+    },
+    "@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "17.0.32",
@@ -11636,6 +11688,11 @@
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
       "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
     },
+    "sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw=="
+    },
     "secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -12309,6 +12366,20 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
+    },
+    "xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -37,13 +37,15 @@
     "p-limit": "^3.1.0",
     "pino": "^10.1.0",
     "pino-pretty": "^10.0.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/luxon": "^3.3.6",
     "@types/node": "^20.10.0",
     "@types/uuid": "^9.0.7",
+    "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "jest": "^29.7.0",

--- a/src/converters/cobertura.ts
+++ b/src/converters/cobertura.ts
@@ -8,9 +8,9 @@ export interface CoberturaReport {
   coverage: {
     $: {
       'line-rate': string;
-      'lines-covered': string;
-      'lines-valid': string;
-      timestamp: string;
+      'lines-covered'?: string;
+      'lines-valid'?: string;
+      timestamp?: string;
     };
   };
 }
@@ -29,6 +29,7 @@ export class CoberturaConverter extends Converter {
     const coverageValue = lineRate * 100;
     const commitSha = config.commit;
 
+    // Cobertura timestamps are Unix epoch seconds; convert to milliseconds for Date
     const timestamp = attrs?.timestamp;
     const createdAt = timestamp
       ? new Date(parseInt(timestamp, 10) * 1000).toISOString()

--- a/src/converters/cobertura.ts
+++ b/src/converters/cobertura.ts
@@ -1,0 +1,82 @@
+import { Mutation, QueryBuilder } from 'faros-js-client';
+
+import { Converter } from '../converter';
+import { CodeQualityCategory, CodeQualityMetricType } from '../types';
+import { Config, createCodeCoveragePercentMutations } from './common';
+
+export interface CoberturaReport {
+  coverage: {
+    $: {
+      'line-rate': string;
+      'lines-covered': string;
+      'lines-valid': string;
+      timestamp: string;
+    };
+  };
+}
+
+export class CoberturaConverter extends Converter {
+  convert(
+    data: CoberturaReport,
+    config: Config,
+    qb: QueryBuilder,
+  ): Array<Mutation> {
+    const attrs = data?.coverage?.$;
+    const lineRate = parseFloat(attrs?.['line-rate']);
+    if (isNaN(lineRate)) {
+      return [];
+    }
+    const coverageValue = lineRate * 100;
+    const commitSha = config.commit;
+
+    const timestamp = attrs?.timestamp;
+    const createdAt = timestamp
+      ? new Date(parseInt(timestamp, 10) * 1000).toISOString()
+      : config.createdAt;
+
+    const mutations = createCodeCoveragePercentMutations({
+      coverageValue,
+      commitSha,
+      createdAt,
+      config,
+      qb,
+    });
+
+    // Enrich the qa_CodeQuality mutation with additional Cobertura metrics
+    if (mutations.length > 0) {
+      const codeQualityMutation = mutations[0] as any;
+      const obj =
+        codeQualityMutation.mutation.insert_qa_CodeQuality_one.__args.object;
+
+      const linesValid = parseInt(attrs?.['lines-valid'], 10);
+      const linesCovered = parseInt(attrs?.['lines-covered'], 10);
+
+      obj.lineCoverage = {
+        category: CodeQualityCategory.Coverage,
+        type: CodeQualityMetricType.Percent,
+        name: 'Line Coverage',
+        value: coverageValue,
+      };
+
+      if (!isNaN(linesValid)) {
+        obj.linesToCover = {
+          category: CodeQualityCategory.Coverage,
+          type: CodeQualityMetricType.Int,
+          name: 'Lines to Cover',
+          value: linesValid,
+        };
+
+        if (!isNaN(linesCovered)) {
+          obj.uncoveredLines = {
+            category: CodeQualityCategory.Coverage,
+            type: CodeQualityMetricType.Int,
+            name: 'Uncovered Lines',
+            value: linesValid - linesCovered,
+          };
+        }
+      }
+    }
+
+    return mutations;
+  }
+}

--- a/src/converters/index.ts
+++ b/src/converters/index.ts
@@ -1,3 +1,4 @@
+export * from './cobertura';
 export * from './codeclimate';
 export * from './common';
 export * from './sarif';

--- a/src/scan-results-reporter.ts
+++ b/src/scan-results-reporter.ts
@@ -4,7 +4,10 @@ import pLimit from 'p-limit';
 import { Logger } from 'pino';
 import { VError } from 'verror';
 
+import { parseStringPromise } from 'xml2js';
+
 import { SemgrepConverter } from './converters';
+import { CoberturaConverter } from './converters/cobertura';
 import { CodeClimateConverter } from './converters/codeclimate';
 import { Config } from './converters/common';
 import { IstanbulConverter } from './converters/istanbul';
@@ -17,6 +20,7 @@ export enum ScanTool {
   Semgrep = 'semgrep',
   Istanbul = 'istanbul',
   Sarif = 'sarif',
+  Cobertura = 'cobertura',
 }
 
 export type ScanResultsReporterConfig = {
@@ -64,10 +68,16 @@ export class ScanResultsReporter {
 
     for (const file of files) {
       this.log.debug('Processing scan results in file: %s', file);
-      const result = JSON.parse(fs.readFileSync(`${file}`, 'utf8'));
+      const fileContent = fs.readFileSync(`${file}`, 'utf8');
+      const result =
+        this.config.tool === ScanTool.Cobertura
+          ? await parseStringPromise(fileContent)
+          : JSON.parse(fileContent);
 
       for (const batch of this.getMutationBatches(result, this.config)) {
-        if (this.config.dryRun !== true) {
+        if (this.config.dryRun) {
+          this.log.info(JSON.stringify(batch, null, 2));
+        } else {
           workerPromises.push(
             limit(async () => {
               try {
@@ -155,6 +165,13 @@ export class ScanResultsReporter {
         break;
       case ScanTool.Sarif:
         mutations = new SarifConverter().convert(
+          data,
+          converterConf,
+          this.qb,
+        );
+        break;
+      case ScanTool.Cobertura:
+        mutations = new CoberturaConverter().convert(
           data,
           converterConf,
           this.qb,

--- a/test/converters/__snapshots__/cobertura.test.ts.snap
+++ b/test/converters/__snapshots__/cobertura.test.ts.snap
@@ -1,0 +1,1590 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CoberturaConverter should convert data to mutations 1`] = `
+Array [
+  Object {
+    "mutation": Object {
+      "insert_qa_CodeQuality_one": Object {
+        "__args": Object {
+          "object": Object {
+            "application": Object {
+              "data": Object {
+                "name": "app-name",
+                "platform": "platform-name",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "compute_Application_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "coverage": Object {
+              "category": "Coverage",
+              "name": "Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "createdAt": "2024-03-28T16:00:05.000Z",
+            "lineCoverage": Object {
+              "category": "Coverage",
+              "name": "Line Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "linesToCover": Object {
+              "category": "Coverage",
+              "name": "Lines to Cover",
+              "type": "Int",
+              "value": 1000,
+            },
+            "origin": "my-origin",
+            "pullRequest": Object {
+              "data": Object {
+                "number": 123,
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_PullRequest_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "uid": "my-uuid",
+            "uncoveredLines": Object {
+              "category": "Coverage",
+              "name": "Uncovered Lines",
+              "type": "Int",
+              "value": 150,
+            },
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "qa_CodeQuality_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "uid",
+              },
+              EnumType {
+                "value": "coverage",
+              },
+              EnumType {
+                "value": "createdAt",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "pullRequestId",
+              },
+              EnumType {
+                "value": "applicationId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+  Object {
+    "mutation": Object {
+      "insert_vcs_Branch_one": Object {
+        "__args": Object {
+          "object": Object {
+            "name": "main",
+            "origin": "my-origin",
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "vcs_Branch_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "name",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+  Object {
+    "mutation": Object {
+      "insert_vcs_BranchCommitAssociation_one": Object {
+        "__args": Object {
+          "object": Object {
+            "branch": Object {
+              "data": Object {
+                "name": "main",
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Branch_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "origin": "my-origin",
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "vcs_BranchCommitAssociation_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "branchId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`CoberturaConverter should convert data to mutations without branch 1`] = `
+Array [
+  Object {
+    "mutation": Object {
+      "insert_qa_CodeQuality_one": Object {
+        "__args": Object {
+          "object": Object {
+            "application": Object {
+              "data": Object {
+                "name": "app-name",
+                "platform": "platform-name",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "compute_Application_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "coverage": Object {
+              "category": "Coverage",
+              "name": "Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "createdAt": "2024-03-28T16:00:05.000Z",
+            "lineCoverage": Object {
+              "category": "Coverage",
+              "name": "Line Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "linesToCover": Object {
+              "category": "Coverage",
+              "name": "Lines to Cover",
+              "type": "Int",
+              "value": 1000,
+            },
+            "origin": "my-origin",
+            "pullRequest": Object {
+              "data": Object {
+                "number": 123,
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_PullRequest_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "uid": "my-uuid",
+            "uncoveredLines": Object {
+              "category": "Coverage",
+              "name": "Uncovered Lines",
+              "type": "Int",
+              "value": 150,
+            },
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "qa_CodeQuality_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "uid",
+              },
+              EnumType {
+                "value": "coverage",
+              },
+              EnumType {
+                "value": "createdAt",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "pullRequestId",
+              },
+              EnumType {
+                "value": "applicationId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`CoberturaConverter should convert data to mutations without commit 1`] = `
+Array [
+  Object {
+    "mutation": Object {
+      "insert_qa_CodeQuality_one": Object {
+        "__args": Object {
+          "object": Object {
+            "application": Object {
+              "data": Object {
+                "name": "app-name",
+                "platform": "platform-name",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "compute_Application_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "coverage": Object {
+              "category": "Coverage",
+              "name": "Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "createdAt": "2024-03-28T16:00:05.000Z",
+            "lineCoverage": Object {
+              "category": "Coverage",
+              "name": "Line Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "linesToCover": Object {
+              "category": "Coverage",
+              "name": "Lines to Cover",
+              "type": "Int",
+              "value": 1000,
+            },
+            "origin": "my-origin",
+            "pullRequest": Object {
+              "data": Object {
+                "number": 123,
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_PullRequest_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "uid": "my-uuid",
+            "uncoveredLines": Object {
+              "category": "Coverage",
+              "name": "Uncovered Lines",
+              "type": "Int",
+              "value": 150,
+            },
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "qa_CodeQuality_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "uid",
+              },
+              EnumType {
+                "value": "coverage",
+              },
+              EnumType {
+                "value": "createdAt",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "pullRequestId",
+              },
+              EnumType {
+                "value": "applicationId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`CoberturaConverter should fall back to config createdAt when no timestamp 1`] = `
+Array [
+  Object {
+    "mutation": Object {
+      "insert_qa_CodeQuality_one": Object {
+        "__args": Object {
+          "object": Object {
+            "application": Object {
+              "data": Object {
+                "name": "app-name",
+                "platform": "platform-name",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "compute_Application_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "coverage": Object {
+              "category": "Coverage",
+              "name": "Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "createdAt": "2024-03-28T16:20:05.474Z",
+            "lineCoverage": Object {
+              "category": "Coverage",
+              "name": "Line Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "linesToCover": Object {
+              "category": "Coverage",
+              "name": "Lines to Cover",
+              "type": "Int",
+              "value": 1000,
+            },
+            "origin": "my-origin",
+            "pullRequest": Object {
+              "data": Object {
+                "number": 123,
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_PullRequest_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "uid": "my-uuid",
+            "uncoveredLines": Object {
+              "category": "Coverage",
+              "name": "Uncovered Lines",
+              "type": "Int",
+              "value": 150,
+            },
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "qa_CodeQuality_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "uid",
+              },
+              EnumType {
+                "value": "coverage",
+              },
+              EnumType {
+                "value": "createdAt",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "pullRequestId",
+              },
+              EnumType {
+                "value": "applicationId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+  Object {
+    "mutation": Object {
+      "insert_vcs_Branch_one": Object {
+        "__args": Object {
+          "object": Object {
+            "name": "main",
+            "origin": "my-origin",
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "vcs_Branch_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "name",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+  Object {
+    "mutation": Object {
+      "insert_vcs_BranchCommitAssociation_one": Object {
+        "__args": Object {
+          "object": Object {
+            "branch": Object {
+              "data": Object {
+                "name": "main",
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Branch_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "origin": "my-origin",
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "vcs_BranchCommitAssociation_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "branchId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`CoberturaConverter should use timestamp from report as createdAt 1`] = `
+Array [
+  Object {
+    "mutation": Object {
+      "insert_qa_CodeQuality_one": Object {
+        "__args": Object {
+          "object": Object {
+            "application": Object {
+              "data": Object {
+                "name": "app-name",
+                "platform": "platform-name",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "compute_Application_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "coverage": Object {
+              "category": "Coverage",
+              "name": "Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "createdAt": "2024-03-28T16:00:05.000Z",
+            "lineCoverage": Object {
+              "category": "Coverage",
+              "name": "Line Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "linesToCover": Object {
+              "category": "Coverage",
+              "name": "Lines to Cover",
+              "type": "Int",
+              "value": 1000,
+            },
+            "origin": "my-origin",
+            "pullRequest": Object {
+              "data": Object {
+                "number": 123,
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_PullRequest_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "uid": "my-uuid",
+            "uncoveredLines": Object {
+              "category": "Coverage",
+              "name": "Uncovered Lines",
+              "type": "Int",
+              "value": 150,
+            },
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "qa_CodeQuality_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "uid",
+              },
+              EnumType {
+                "value": "coverage",
+              },
+              EnumType {
+                "value": "createdAt",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "pullRequestId",
+              },
+              EnumType {
+                "value": "applicationId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+  Object {
+    "mutation": Object {
+      "insert_vcs_Branch_one": Object {
+        "__args": Object {
+          "object": Object {
+            "name": "main",
+            "origin": "my-origin",
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "vcs_Branch_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "name",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+  Object {
+    "mutation": Object {
+      "insert_vcs_BranchCommitAssociation_one": Object {
+        "__args": Object {
+          "object": Object {
+            "branch": Object {
+              "data": Object {
+                "name": "main",
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Branch_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "origin": "my-origin",
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "vcs_BranchCommitAssociation_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "branchId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+]
+`;

--- a/test/converters/__snapshots__/cobertura.test.ts.snap
+++ b/test/converters/__snapshots__/cobertura.test.ts.snap
@@ -1187,6 +1187,792 @@ Array [
 ]
 `;
 
+exports[`CoberturaConverter should handle missing lines-covered 1`] = `
+Array [
+  Object {
+    "mutation": Object {
+      "insert_qa_CodeQuality_one": Object {
+        "__args": Object {
+          "object": Object {
+            "application": Object {
+              "data": Object {
+                "name": "app-name",
+                "platform": "platform-name",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "compute_Application_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "coverage": Object {
+              "category": "Coverage",
+              "name": "Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "createdAt": "2024-03-28T16:00:05.000Z",
+            "lineCoverage": Object {
+              "category": "Coverage",
+              "name": "Line Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "linesToCover": Object {
+              "category": "Coverage",
+              "name": "Lines to Cover",
+              "type": "Int",
+              "value": 1000,
+            },
+            "origin": "my-origin",
+            "pullRequest": Object {
+              "data": Object {
+                "number": 123,
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_PullRequest_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "uid": "my-uuid",
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "qa_CodeQuality_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "uid",
+              },
+              EnumType {
+                "value": "coverage",
+              },
+              EnumType {
+                "value": "createdAt",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "pullRequestId",
+              },
+              EnumType {
+                "value": "applicationId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+  Object {
+    "mutation": Object {
+      "insert_vcs_Branch_one": Object {
+        "__args": Object {
+          "object": Object {
+            "name": "main",
+            "origin": "my-origin",
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "vcs_Branch_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "name",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+  Object {
+    "mutation": Object {
+      "insert_vcs_BranchCommitAssociation_one": Object {
+        "__args": Object {
+          "object": Object {
+            "branch": Object {
+              "data": Object {
+                "name": "main",
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Branch_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "origin": "my-origin",
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "vcs_BranchCommitAssociation_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "branchId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+]
+`;
+
+exports[`CoberturaConverter should handle missing lines-valid 1`] = `
+Array [
+  Object {
+    "mutation": Object {
+      "insert_qa_CodeQuality_one": Object {
+        "__args": Object {
+          "object": Object {
+            "application": Object {
+              "data": Object {
+                "name": "app-name",
+                "platform": "platform-name",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "compute_Application_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "coverage": Object {
+              "category": "Coverage",
+              "name": "Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "createdAt": "2024-03-28T16:00:05.000Z",
+            "lineCoverage": Object {
+              "category": "Coverage",
+              "name": "Line Coverage",
+              "type": "Percent",
+              "value": 85,
+            },
+            "origin": "my-origin",
+            "pullRequest": Object {
+              "data": Object {
+                "number": 123,
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_PullRequest_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "uid": "my-uuid",
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "qa_CodeQuality_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "uid",
+              },
+              EnumType {
+                "value": "coverage",
+              },
+              EnumType {
+                "value": "createdAt",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "pullRequestId",
+              },
+              EnumType {
+                "value": "applicationId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+  Object {
+    "mutation": Object {
+      "insert_vcs_Branch_one": Object {
+        "__args": Object {
+          "object": Object {
+            "name": "main",
+            "origin": "my-origin",
+            "repository": Object {
+              "data": Object {
+                "name": "repo-name",
+                "organization": Object {
+                  "data": Object {
+                    "source": "source-name",
+                    "uid": "org-name",
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Organization_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Repository_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "vcs_Branch_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "name",
+              },
+              EnumType {
+                "value": "repositoryId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+  Object {
+    "mutation": Object {
+      "insert_vcs_BranchCommitAssociation_one": Object {
+        "__args": Object {
+          "object": Object {
+            "branch": Object {
+              "data": Object {
+                "name": "main",
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Branch_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "commit": Object {
+              "data": Object {
+                "repository": Object {
+                  "data": Object {
+                    "name": "repo-name",
+                    "organization": Object {
+                      "data": Object {
+                        "source": "source-name",
+                        "uid": "org-name",
+                      },
+                      "on_conflict": Object {
+                        "constraint": EnumType {
+                          "value": "vcs_Organization_pkey",
+                        },
+                        "update_columns": Array [
+                          EnumType {
+                            "value": "refreshedAt",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  "on_conflict": Object {
+                    "constraint": EnumType {
+                      "value": "vcs_Repository_pkey",
+                    },
+                    "update_columns": Array [
+                      EnumType {
+                        "value": "refreshedAt",
+                      },
+                    ],
+                  },
+                },
+                "sha": "commit-hash",
+              },
+              "on_conflict": Object {
+                "constraint": EnumType {
+                  "value": "vcs_Commit_pkey",
+                },
+                "update_columns": Array [
+                  EnumType {
+                    "value": "refreshedAt",
+                  },
+                ],
+              },
+            },
+            "origin": "my-origin",
+          },
+          "on_conflict": Object {
+            "constraint": EnumType {
+              "value": "vcs_BranchCommitAssociation_pkey",
+            },
+            "update_columns": Array [
+              EnumType {
+                "value": "refreshedAt",
+              },
+              EnumType {
+                "value": "commitId",
+              },
+              EnumType {
+                "value": "branchId",
+              },
+              EnumType {
+                "value": "origin",
+              },
+            ],
+          },
+        },
+        "id": true,
+      },
+    },
+  },
+]
+`;
+
 exports[`CoberturaConverter should use timestamp from report as createdAt 1`] = `
 Array [
   Object {

--- a/test/converters/cobertura.test.ts
+++ b/test/converters/cobertura.test.ts
@@ -1,0 +1,113 @@
+import { QueryBuilder } from 'faros-js-client';
+
+import {
+  CoberturaConverter,
+  CoberturaReport,
+} from '../../src/converters/cobertura';
+import { Config } from '../../src/converters/common';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('my-uuid'),
+}));
+
+describe('CoberturaConverter', () => {
+  const config: Config = {
+    createdAt: '2024-03-28T16:20:05.474Z',
+    repoInfo: {
+      name: 'repo-name',
+      organization: 'org-name',
+      source: 'source-name',
+    },
+    pullRequest: 123,
+    appInfo: {
+      name: 'app-name',
+      platform: 'platform-name',
+    },
+    commit: 'commit-hash',
+    branch: 'main',
+  };
+  const data: CoberturaReport = {
+    coverage: {
+      $: {
+        'line-rate': '0.85',
+        'lines-covered': '850',
+        'lines-valid': '1000',
+        timestamp: '1711641605',
+      },
+    },
+  };
+  let converter: CoberturaConverter;
+
+  beforeEach(() => {
+    converter = new CoberturaConverter();
+  });
+
+  it('should convert data to mutations', () => {
+    const result = converter.convert(
+      data,
+      config,
+      new QueryBuilder('my-origin'),
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should use timestamp from report as createdAt', () => {
+    const result = converter.convert(
+      data,
+      { ...config, createdAt: '2020-01-01T00:00:00.000Z' },
+      new QueryBuilder('my-origin'),
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should fall back to config createdAt when no timestamp', () => {
+    const dataNoTimestamp: CoberturaReport = {
+      coverage: {
+        $: {
+          'line-rate': '0.85',
+          'lines-covered': '850',
+          'lines-valid': '1000',
+          timestamp: undefined,
+        },
+      },
+    };
+    const result = converter.convert(
+      dataNoTimestamp,
+      config,
+      new QueryBuilder('my-origin'),
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should convert data to mutations without commit', () => {
+    const result = converter.convert(
+      data,
+      { ...config, commit: undefined },
+      new QueryBuilder('my-origin'),
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should convert data to mutations without branch', () => {
+    const result = converter.convert(
+      data,
+      { ...config, branch: undefined },
+      new QueryBuilder('my-origin'),
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should return empty array for invalid data', () => {
+    const invalidData = {};
+    const minConfig: Config = {
+      createdAt: '2024-03-28T16:20:05.474Z',
+    };
+
+    const result = converter.convert(
+      invalidData as CoberturaReport,
+      minConfig,
+      new QueryBuilder('my-origin'),
+    );
+    expect(result).toEqual([]);
+  });
+});

--- a/test/converters/cobertura.test.ts
+++ b/test/converters/cobertura.test.ts
@@ -97,6 +97,42 @@ describe('CoberturaConverter', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('should handle missing lines-valid', () => {
+    const dataNoValid: CoberturaReport = {
+      coverage: {
+        $: {
+          'line-rate': '0.85',
+          'lines-covered': '850',
+          timestamp: '1711641605',
+        },
+      },
+    };
+    const result = converter.convert(
+      dataNoValid,
+      config,
+      new QueryBuilder('my-origin'),
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should handle missing lines-covered', () => {
+    const dataNoConvered: CoberturaReport = {
+      coverage: {
+        $: {
+          'line-rate': '0.85',
+          'lines-valid': '1000',
+          timestamp: '1711641605',
+        },
+      },
+    };
+    const result = converter.convert(
+      dataNoConvered,
+      config,
+      new QueryBuilder('my-origin'),
+    );
+    expect(result).toMatchSnapshot();
+  });
+
   it('should return empty array for invalid data', () => {
     const invalidData = {};
     const minConfig: Config = {


### PR DESCRIPTION
## Summary

Added `--tool cobertura` support to the Faros Scan Results Reporter, enabling upload of Cobertura XML coverage reports (e.g. from OpenCppCoverage). Also fixed `--dry-run` to print mutations instead of silently skipping.

## Data written

A single `qa_CodeQuality` record with **aggregate-level** metrics:

| Field | Source | Type |
|-------|--------|------|
| `coverage` | `line-rate × 100` | Percent |
| `lineCoverage` | `line-rate × 100` | Percent |
| `linesToCover` | `lines-valid` | Int |
| `uncoveredLines` | `lines-valid - lines-covered` | Int |

Plus associated `vcs_Branch` and `vcs_BranchCommitAssociation` records when `--commit` and `--branch` are provided.

## What's ignored

The Cobertura XML contains per-file and per-line granularity (234 classes, 51,843 lines with individual hit counts in the sample report) — none of this is used. Branch coverage, complexity, and method-level data are also ignored (and are always zero in OpenCppCoverage output anyway).

## How support could be extended

- **Per-file coverage**: The `qa_CodeQuality` model is per-repo, not per-file. Supporting file-level coverage would require a new Faros model or writing one `qa_CodeQuality` record per file.
- **Branch coverage**: If a Cobertura producer emits non-zero `branch-rate`, it could populate the `branchCoverage` field on `qa_CodeQuality`.
- **Trend tracking**: Writing records per commit over time enables coverage trend analysis.

## Example upload command

```bash
./bin/faros-scan-result-reporter Coverage.xml \
  --tool cobertura \
  -k "$FAROS_API_KEY" \
  --repository my-repo \
  --organization my-org \
  --source github \
  --commit abc123 \
  --branch main
```

## Test plan
- [x] Unit tests for CoberturaConverter (6 tests, 5 snapshots)
- [x] All existing tests pass (16/16)
- [x] Dry-run verified against real OpenCppCoverage XML report

🤖 Generated with [Claude Code](https://claude.com/claude-code)