### PR TITLE
FAI-19161 Fix release workflow: use local cosign action

### DIFF
--- a/.github/actions/sign_image_with_cosign/action.yml
+++ b/.github/actions/sign_image_with_cosign/action.yml
@@ -1,0 +1,98 @@
+name: Sign Image with Cosign (Auto Digest Lookup)
+description: |
+  Signs an image with Cosign using GitHub OIDC.
+
+inputs:
+  dockerhub-username:
+    description: "Docker Hub username"
+    required: true
+  dockerhub-token:
+    description: "Docker Hub token or password"
+    required: true
+  docker-image:
+    description: "Docker image with tag without registry prefix (e.g. farosai/airbyte-xyz:3.4.5)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.dockerhub-username }}" ]; then
+          echo "Error: dockerhub-username is required"
+          exit 1
+        fi
+        if [ -z "${{ inputs.dockerhub-token }}" ]; then
+          echo "Error: dockerhub-token is required"
+          exit 1
+        fi
+        if [ -z "${{ inputs.docker-image }}" ]; then
+          echo "Error: docker-image is required"
+          exit 1
+        fi
+        # Validate docker-image format: should be name:tag (no digest, no empty tag)
+        if ! [[ "${{ inputs.docker-image }}" =~ ^[a-zA-Z0-9._/-]+:[a-zA-Z0-9._-]+$ ]]; then
+          echo "Error: docker-image must be in the format 'name:tag' (e.g. farosai/airbyte-xyz:3.4.5)"
+          exit 1
+        fi
+    - name: Install Skopeo
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y skopeo
+
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+
+    - name: Fetch digest using skopeo
+      id: get-digest
+      shell: bash
+      run: |
+        IMAGE="docker.io/${{ inputs.docker-image }}"
+        echo "Inspecting remote image: $IMAGE"
+
+        DIGEST=$(skopeo inspect "docker://$IMAGE" --format "{{.Digest}}")
+        echo "Digest: $DIGEST"
+        echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+    - name: Sign and verify image
+      shell: bash
+      run: |
+        # Construct full image reference with digest
+        IMAGE_NAME="${{ inputs.docker-image }}"
+        IMAGE_REF="$IMAGE_NAME@${{ steps.get-digest.outputs.digest }}"
+
+        echo "Signing image: ${IMAGE_REF}"
+        if ! cosign sign --yes "${IMAGE_REF}"; then
+          echo "Error: Failed to sign image ${IMAGE_REF}" >&2
+          exit 1
+        fi
+
+        echo "Verifying image: ${IMAGE_REF}"
+        MAX_ATTEMPTS=2
+        ATTEMPT=1
+        SLEEP_SECONDS=5
+        while true; do
+          if [ "${ATTEMPT}" -gt "${MAX_ATTEMPTS}" ]; then
+            echo "Error: Verification failed after ${MAX_ATTEMPTS} attempts for ${IMAGE_REF}" >&2
+            exit 1
+          fi
+
+          if cosign verify "${IMAGE_REF}" \
+            --certificate-identity-regexp="https://github.com/${{ github.repository }}/.*" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com"; then
+            echo "Verification succeeded for ${IMAGE_REF}"
+            break
+          fi
+
+          echo "Verification failed (attempt ${ATTEMPT}/${MAX_ATTEMPTS}). Retrying in ${SLEEP_SECONDS} seconds."
+          ATTEMPT=$(( ATTEMPT + 1 ))
+          sleep "${SLEEP_SECONDS}"
+        done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           docker push $VERSION_TAG
       
       - name: Sign image
-        uses: faros-ai/airbyte-connectors/.github/actions/sign_image_with_cosign@3fe8e36cd116cb4ed735317c604122b7326afec5
+        uses: ./.github/actions/sign_image_with_cosign
         with:
           docker-image: ${{ env.VERSION_TAG }}
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary
- The release workflow references `faros-ai/airbyte-connectors/.github/actions/sign_image_with_cosign` which is no longer resolvable
- Copies the action locally to `.github/actions/sign_image_with_cosign/`
- Updates `release.yml` to use the local action

Long-term, this action should live in a dedicated repo (e.g. `faros-ai/sign-image-with-cosign`) so it can be versioned and shared across repos.

## Test plan
- [x] Workflow YAML is valid
- [ ] Verify on next release that image signing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)